### PR TITLE
#814: Change the sort field in the query to get latest videos to `publishedAt`

### DIFF
--- a/src/api/getLatestVideos.js
+++ b/src/api/getLatestVideos.js
@@ -56,7 +56,7 @@ const getLatestVideos = (filters) => {
     input: {
       limit: 25,
       sort: {
-        sort: 'id',
+        sort: 'publishedAt',
         ascending: false,
       },
       filter: {


### PR DESCRIPTION
For [Oovvuu/platform-planning#814](https://github.com/Oovvuu/platform-planning/issues/814)